### PR TITLE
fix for marking edited file dirty after cancelled autocomplete 

### DIFF
--- a/editorcomp/src/Editor.cpp
+++ b/editorcomp/src/Editor.cpp
@@ -284,7 +284,15 @@ void Editor::putSuggestion() {
                     this->suggestion = fi.substr(prefix.length(), cp - prefix.length());
                     this->suggestionRow = ei.CurLine;
                     this->suggestionCol = ei.CurPos;
+
+                    EditorUndoRedo eur = {0};
+                    eur.Command = EUR_BEGIN;
+                    info.EditorControl(ECTL_UNDOREDO, &eur);
+
                     info.EditorControl(ECTL_INSERTTEXT, (void *) suggestion.c_str());
+
+                    eur.Command = EUR_END;
+                    info.EditorControl(ECTL_UNDOREDO, &eur);
 
 #if defined(DEBUG_EDITORCOMP)
                     debug("Added suggestion of length " + std::to_string(suggestion.length()) +
@@ -359,8 +367,9 @@ void Editor::declineSuggestion() {
 
         const EditorInfo &editorInfo = getInfo();
         if (editorInfo.CurLine == suggestionRow && editorInfo.CurPos == suggestionCol) {
-            for (int i = 0; i < int(suggestion.length()); i++)
-                info.EditorControl(ECTL_DELETECHAR, nullptr);
+            EditorUndoRedo eur = {0};
+            eur.Command = EUR_UNDO;
+            info.EditorControl(ECTL_UNDOREDO, &eur);
         } else {
             int beforeRow = editorInfo.CurLine;
             int beforeCol = editorInfo.CurPos;


### PR DESCRIPTION
fix for https://github.com/elfmz/far2l/issues/342
Undo (ECTL_UNDOREDO) should be used instead of suggested characters removal (ECTL_DELETECHAR) when user cancels suggestion.
For proper operation suggestion is enclosed with EUR_BEGIN/EUR_END requests