### PR TITLE
fix conflicting shortcuts in Options menu

### DIFF
--- a/far2l/bootstrap/scripts/farlang.templ.m4
+++ b/far2l/bootstrap/scripts/farlang.templ.m4
@@ -11082,7 +11082,7 @@ upd:"No&tifications settings"
 
 MMenuCodePages
 "Кодов&ые страницы"
-upd:"Cod&e pages"
+upd:"&Code pages"
 upd:"Znakové sady:"
 upd:"Tabellen"
 upd:"Kódlapok"


### PR DESCRIPTION
Code Pages has 'e' as shortcut like Editor settings in F9-Options menu
Changed to 'c'