### PR TITLE
Fix for CopyToSelf check

### DIFF
--- a/far2l/copy.cpp
+++ b/far2l/copy.cpp
@@ -486,9 +486,11 @@ CopyProgress *CP;
 
 static int CmpFullNames(const wchar_t *Src,const wchar_t *Dest)
 {
-	FARString strSrcFullName = Src, strDestFullName = Dest;
+	FARString strSrcFullName, strDestFullName;
 
 	// получим полные пути с учетом символических связей
+    	ConvertNameToFull(Src, strSrcFullName);
+    	ConvertNameToFull(Dest, strDestFullName);
 	DeleteEndSlash(strSrcFullName);
 	DeleteEndSlash(strDestFullName);
 


### PR DESCRIPTION
CmpFullNames() didn't use ConvertNameToFull() 
this caused CopyToSelf check to fail in case of copying files from current directory to itself, but with full path specification like this:
*.cpp  -> /full/path/to/current/dir/ 
So it was possible to mistakenly truncate all copied files to 0 
Proposed patch fixes this problem.