### PR TITLE
fix for wrong detection files as Unicode

### DIFF
--- a/far2l/filestr.cpp
+++ b/far2l/filestr.cpp
@@ -925,7 +925,10 @@ bool GetFileFormat(File& file, UINT& nCodePage, bool* pSignatureFound, bool bUse
 					}
 				}
 			}
-			else if (IsTextUTF8(reinterpret_cast<LPBYTE>(Buffer), ReadSize))
+			if(bDetect) {
+				// do nothing
+			} else
+			if (IsTextUTF8(reinterpret_cast<LPBYTE>(Buffer), ReadSize))
 			{
 				nCodePage=CP_UTF8;
 				bDetect=true;
@@ -936,6 +939,7 @@ bool GetFileFormat(File& file, UINT& nCodePage, bool* pSignatureFound, bool bUse
 				ns->HandleData(reinterpret_cast<LPCSTR>(Buffer), ReadSize);
 				ns->DataEnd();
 				int cp = ns->getCodePage();
+				float r = ns->GetConfidence();
 
 				if (cp != -1)
 				{


### PR DESCRIPTION
originally IsTextUnicode was used as the 1st test for unicode. 
Them return flags are checked if it is REALLY unicode.
Below we had UTF8 and euristic codepage checks
But due to wrong condition we never get to these check if IsTextUnicode reported that MY BY we have unicode check, regardless of further inspection on our side.
Actually we should continue with codepage checks if IsTextUnicode returns TRUE, but flag analysis tells that it doesn not.